### PR TITLE
Return actual request error instead of throwing it

### DIFF
--- a/force-app/main/aura/LC_API/LC_APIHelper.js
+++ b/force-app/main/aura/LC_API/LC_APIHelper.js
@@ -117,7 +117,7 @@ License: BSD 3-Clause License
             if ( response.success ) {
                 return response.data;
             } else {
-                throw new Error( response.data );
+                return Promise.reject( response.data );
             }
         }));
 


### PR DESCRIPTION
Hi!

I thought that this change might be interesting for anyone who wants to perform different behaviours depending on the data returned in the request.

This is useful if your API response contains an object. As Error class constructor takes a String type parameter, the object is converted to a String. Thus what you get on the `.catch` function on the promise is a `[Object object]` value instead of the actual object.

So, with this change, if your API returned a String you would get the same parameter value in your catch function as in the previous code. But if your API returned an Object response, you'd get the actual object rather than its string version.